### PR TITLE
Two JavaScript improvements

### DIFF
--- a/js/scroll-to-anchor.js
+++ b/js/scroll-to-anchor.js
@@ -21,10 +21,8 @@ jQuery(document).ready(function($) {
       //Split link into part before and after hash mark #
       var linktHref = this.href.split('#');
 
-
       if (linktHref[1] === '') { // Exception #4: orphaned # at end of URL
-        e.preventDefault();
-        return false;
+        return;
       }
 
       var currentUrlRoot = window.location.href.split('#')[0],
@@ -33,20 +31,17 @@ jQuery(document).ready(function($) {
       currentUrlRoot = currentUrlRoot.replace(/\/$/, '');
       linktHref[0] = linktHref[0].replace(/\/$/, '');
 
-      // Animate for targets on the same page.
-      if (linktHref[0] === currentUrlRoot && scrollToAnchor.length ) {
-        $('html, body')
-          .animate({
-            scrollTop: scrollToAnchor.offset().top - sta_settings.distance
-          }, parseInt(sta_settings.speed, 10));
-
-        e.preventDefault();
-        return false;
-      } else {
-        // For targets on other pages, just go to URL.
-        window.location.href = this.href;
+      // Do not animate for targets on another page
+      if ( linktHref[0] !== currentUrlRoot || ! scrollToAnchor.length ) {
+        return;
       }
 
+      $('html, body')
+        .animate({
+          scrollTop: scrollToAnchor.offset().top - sta_settings.distance
+        }, parseInt(sta_settings.speed, 10));
+
+      e.preventDefault();
       return false;
     });
 });

--- a/js/scroll-to-anchor.js
+++ b/js/scroll-to-anchor.js
@@ -34,7 +34,7 @@ jQuery(document).ready(function($) {
       linktHref[0] = linktHref[0].replace(/\/$/, '');
 
       // Animate for targets on the same page.
-      if (linktHref[0] === currentUrlRoot) {
+      if (linktHref[0] === currentUrlRoot && scrollToAnchor.length ) {
         $('html, body')
           .animate({
             scrollTop: scrollToAnchor.offset().top - sta_settings.distance


### PR DESCRIPTION
In the pull-request I adjusted two issues:

* scroll to anchor should only happen if the element to scroll to actually exists on the page (see first commit)
* do not handle anything other than the scroll-to-anchor links (see second commit); the problem was that some links contain `#` for other reasons than linking to anchors, and these would break by an `e.preventDefault()`; similarly, not all links containing the `#` are necessarily to be used as links (they might do custom functionality), therefore I removed the `window.location.href = this.href` as well

The second bullet point is mostly about compatibility. It ensures that this plugin really only does what it is supposed to do.

I didn't include a minified file since I'm not sure of your workflow here. :)